### PR TITLE
bump scalafix to fix runtime binary incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Addtional rules for [scalafix](https://github.com/scalacenter/scalafix) that ens
 
 They consist of `Disable` and `MissingFinal` rules. 
 
-Cross-build against Scala 2.12.13 and 2.13.6.
+Cross-build against Scala 2.12.14 and 2.13.6.
 
 ### Installation 
 
 ```sbt
-scalafixDependencies += "com.github.vovapolu" %% "scaluzzi" % "0.1.19"
+scalafixDependencies += "com.github.vovapolu" %% "scaluzzi" % "0.1.20"
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Addtional rules for [scalafix](https://github.com/scalacenter/scalafix) that ens
 
 They consist of `Disable` and `MissingFinal` rules. 
 
-Cross-build against Scala 2.12.14 and 2.13.6.
+Cross-published against Scala 2.12 and 2.13.
 
 ### Installation 
 

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.28")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")


### PR DESCRIPTION
Rules built against scalafix-core 0.9.28 cannot be used by any other runtime version of Scalafix at the moment, so 0.1.19 should not be advertized.
```
Error:  java.lang.NoSuchMethodError: 'void metaconfig.generic.Surface.<init>(scala.collection.immutable.List, scala.collection.immutable.List)'
Error:      at scalafix.internal.scaluzzi.DisableConfig$.<init>(DisableConfig.scala:162)
```

https://gitter.im/scalacenter/scalafix?at=60b41af5688a2624b8bf52c0

cc @sideeffffect